### PR TITLE
Use new BuildKit feature on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
+# syntax=docker/dockerfile:1.4
 FROM lukemathwalker/cargo-chef:latest-rust-1.59.0 AS chef
 WORKDIR /app
 
 FROM chef AS planner
-COPY . .
+COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS build-env 
-COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner --link /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Build application
-COPY . .
+COPY --link . .
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc
 LABEL org.opencontainers.image.source=https://github.com/GiganticMinecraft/SeichiRankingBFF
-COPY --from=build-env /app/target/release/seichi-ranking-bff /
+COPY --from=build-env --link /app/target/release/seichi-ranking-bff /
 CMD ["./seichi-ranking-bff"]


### PR DESCRIPTION
ref. https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/  
https://codezine.jp/article/detail/15745

### Benefits of using --link
Using `--link` allows to reuse already built layers in subsequent builds with `--cache-from` even if the previous layers have changed. This is especially important for multi-stage builds where a `COPY --from` statement would previously get invalidated if any previous commands in the same stage changed, causing the need to rebuild the intermediate stages again. With `--link` the layer the previous build generated is reused and merged on top of the new layers. This also means you can easily rebase your images when the base images receive updates, without having to execute the whole build again. In backends that support it, BuildKit can do this rebase action without the need to push or pull any layers between the client and the registry. BuildKit will detect this case and only create new image manifest that contains the new layers and old layers in correct order.

The same behavior where BuildKit can avoid pulling down the base image can also happen when using `--link` and no other commands that would require access to the files in the base image. In that case BuildKit will only build the layers for the `COPY` commands and push them to the registry directly on top of the layers of the base image.